### PR TITLE
Fix to get metadata.schemes value from config

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -236,6 +236,12 @@ module.exports = function(annotations, router) {
   var pkg = require(path.join(cwd, 'package.json'));
   addInfo(pkg);
 
+  //Add info.schemes if defined in conf
+  if (typeof opts.metadata != 'undefined'
+    && typeof opts.metadata.schemes != 'undefined') {
+    _swaggerData.info.schemes = opts.metadata.schemes;
+  }
+
   // Iterate over our annotations and convert them
   annotations.forEach(function(annotation) {
     switch (annotation.type) {


### PR DESCRIPTION
Fix to generate swagger.metadata.schemes value from swaggerAnnotations({}) configuration, i.e.: ['https']
Default hardcoded value is still ['http']