### PR TITLE
Reinitializes swaggerData before each swaggotate invocation

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -4,21 +4,25 @@ var path = require('path');
 var _ = require('lodash');
 var helpers = require('./helpers');
 
-var _swaggerData = {
-  swagger: '2.0',
-  info: {},
-  host: '',
-  basePath: '',
-  schemes: ['http'],
-  produces: ['application/json'],
-  consumes: ['application/json'],
-  tags: [],
-  paths: {},
-  responses: {},
-  parameters: {},
-  definitions: {}
-};
+var _swaggerData;
 var _router;
+
+function initializeSwaggerData() {
+  return {
+    swagger: '2.0',
+    info: {},
+    host: '',
+    basePath: '',
+    schemes: ['http'],
+    produces: ['application/json'],
+    consumes: ['application/json'],
+    tags: [],
+    paths: {},
+    responses: {},
+    parameters: {},
+    definitions: {}
+  };
+}
 
 function addInfo(pkg) {
   // Add service info from our package.json
@@ -226,6 +230,7 @@ function addDefinition(annotation) {
 }
 
 module.exports = function(annotations, router) {
+  _swaggerData = initializeSwaggerData();
   // Set the reference to our incoming Express router
   _router = _.indexBy(helpers.extractRoutes(router), function(route) {
     return route.handler.name;


### PR DESCRIPTION
### Problem
When generating multiple swagger annotations at a single time, artifacts from previous runs show up in subsequent ones. 

### Use Case
Given a project containing multiple microservices (each contained in its own module inside `apps/`), we can use a script such as the following to programmatically generate `n` number of swagger docs (one for each microservice based on its express route file).

```
function generateSwaggerDoc(filePath) {
    const moduleName = filePath.split(path.sep)[2];
    swaggerAnnotations({
        metadata: {
            // swagger metadata
        },
        src: `./apps/${moduleName}/routes/${moduleName}.routes.js`,
        dest: `./.swagger/${moduleName}`
    });
    const swaggerDoc = `./.swagger/${moduleName}/swagger.json`;
}

const routeFiles = glob.sync('./apps/*/routes/*routes*.js');
_.each(routeFiles, generateSwaggerDoc);
```

### Proposed Solution
This PR creates a `initializeSwaggerData` function that returns an initialized `swaggerData` object. It's called each time swaggotate is executed to ensure that `_swaggerData` has a clean slate between each execution.